### PR TITLE
Отрисовка должна быть отдельным тредом, т.к. интерфейс на слабых компьютерах будет "зависать"

### DIFF
--- a/WpfApp/ViewModels/Command.cs
+++ b/WpfApp/ViewModels/Command.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Shapes;
+using System.Windows.Threading;
 
 namespace WpfApp
 {
@@ -66,14 +67,8 @@ namespace WpfApp
             while (CanDraw)
             {
                 if (++parent == count_child)
-                {
                     count_child *= 2;
-                    Thread.Sleep(1000);
-                }
-                else
-                {
-                    Thread.Sleep(100);
-                }
+
                 DrawObject();
             }
         }
@@ -82,21 +77,22 @@ namespace WpfApp
         /// </summary>
         void DrawObject()
         {
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                if (CanDraw)
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Background,
+                () =>
                 {
-                    Polyline p = new()
+                    if (CanDraw)
                     {
-                        Points = Coordinate.Get(),
-                        Stroke = Brushes.White,
-                        StrokeThickness = 2
-                    };
-                    CollectionFigure.Add(p);
-                    return;
-                }
-                parent--;
-            });
+                        Polyline p = new()
+                        {
+                            Points = Coordinate.Get(),
+                            Stroke = Brushes.White,
+                            StrokeThickness = 2
+                        };
+                        CollectionFigure.Add(p);
+                        return;
+                    }
+                    parent--;
+                });
         }
         #endregion
 

--- a/WpfApp/WpfApp.csproj
+++ b/WpfApp/WpfApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 


### PR DESCRIPTION
Sleep в отрисовке, конечно решает эту проблему, но это затормаживает не являеется спасением в перспективе.

Проблема решается, дополнительные комментарии смотри [тут](https://stackoverflow.com/questions/1644079/change-wpf-controls-from-a-non-main-thread-using-dispatcher-invoke).

И обновитесь вы уже до последнего релиза C#, а то пятая версия .netcore перестанут поддерживать [8го мая](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/).